### PR TITLE
Add shared flag feature

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,15 +1,14 @@
 build --verbose_failures
-build --compiler=compiler
-build --cxxopt=--std=c++14
+build --cxxopt=--std=c++17
 
 build:amd64 --platforms=@local_config_platform//:host
 
-build:armv7hf --crosstool_top=//compilers/arm_compiler:toolchain
-build:armv7hf --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
-build:armv7hf --cpu=armeabi-v7a --compiler=gcc
-build:armv7hf --spawn_strategy=standalone
+build:arm_crosstool --crosstool_top=@murtis_bazel_compilers//compilers/arm_compiler:toolchain
+build:arm_crosstool --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:arm_crosstool --spawn_strategy=standalone
 
-build:aarch64 --crosstool_top=//compilers/arm_compiler:toolchain
-build:aarch64 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:armv7hf --config=arm_crosstool
+build:armv7hf --cpu=armeabi-v7a --compiler=gcc
+
+build:aarch64 --config=arm_crosstool
 build:aarch64 --cpu=aarch64-linux-gnu --compiler=gcc
-build:aarch64 --spawn_strategy=standalone

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repo hosts the bazel compiler defintions for my many cpp projects. I'm not a compiler expert, so use with caution. I'm trying to maintain a Raspberry Pi / Nvidia Jetson suite of compiler definitions in one repository, effectively mirroring the bazel crosstool [here](https://github.com/bazelbuild/bazel/tree/master/src/test/shell/bazel/testdata/bazel_toolchain_test_data)
 
-Requires bazel version >= 0.25.1.
+Requires bazel version >= 0.25.1. It is assumed that bazel is running on an x86_64(amd64) host.
 
 Supported compilers:
 
@@ -32,25 +32,25 @@ cross_compiler_dependencies()
 In your `.bazelrc` file:
 
 ```
-build --compiler=compiler
+build:amd64 --platforms=@local_config_platform//:host
 
-build:armv7hf --crosstool_top=@murtis_bazel_compilers//compilers/arm_compiler:toolchain
-build:armv7hf --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:arm_crosstool --crosstool_top=@murtis_bazel_compilers//compilers/arm_compiler:toolchain
+build:arm_crosstool --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:arm_crosstool --spawn_strategy=standalone
+
+build:armv7hf --config=arm_crosstool
 build:armv7hf --cpu=armeabi-v7a --compiler=gcc
-build:armv7hf --spawn_strategy=standalone
 
-build:aarch64 --crosstool_top=@murtis_bazel_compilers//compilers/arm_compiler:toolchain
-build:aarch64 --host_crosstool_top=@bazel_tools//tools/cpp:toolchain
+build:aarch64 --config=arm_crosstool
 build:aarch64 --cpu=aarch64-linux-gnu --compiler=gcc
-build:aarch64 --spawn_strategy=standalone
 ```
 
 
 Build with:
 
 ```
-# locally executable:
-bazel build //example
+# amd64 executable:
+bazel build --config=amd64 //example # Note, `--config=amd64` can be omitted here.
 
 # Raspberry Pi:
 bazel build --config=armv7hf //example

--- a/compilers/arm_compiler/cc_toolchain_config.bzl
+++ b/compilers/arm_compiler/cc_toolchain_config.bzl
@@ -122,13 +122,13 @@ def _impl(ctx):
             ],
         )
     elif (ctx.attr.cpu == "aarch64-linux-gnu"):
-          objcopy_embed_data_action = action_config(
-              action_name = "objcopy_embed_data",
-              enabled = True,
-              tools = [
-                  tool(path = "linaro_linux_gcc_aarch64/aarch64-linux-gnu-objcopy"),
-              ],
-          )
+        objcopy_embed_data_action = action_config(
+            action_name = "objcopy_embed_data",
+            enabled = True,
+            tools = [
+                tool(path = "linaro_linux_gcc_aarch64/aarch64-linux-gnu-objcopy"),
+            ],
+        )
     elif (ctx.attr.cpu == "k8"):
         objcopy_embed_data_action = action_config(
             action_name = "objcopy_embed_data",
@@ -594,6 +594,19 @@ def _impl(ctx):
         ],
     )
 
+    shared_flag_feature = feature(
+        name = "shared_flag",
+        flag_sets = [
+            flag_set(
+                actions = [
+                    ACTION_NAMES.cpp_link_dynamic_library,
+                    ACTION_NAMES.cpp_link_nodeps_dynamic_library,
+                ],
+                flag_groups = [flag_group(flags = ["-shared"])],
+            ),
+        ],
+    )
+
     sysroot_feature = feature(
         name = "sysroot",
         enabled = True,
@@ -741,6 +754,7 @@ def _impl(ctx):
             default_link_flags_feature,
             supports_dynamic_linker_feature,
             supports_pic_feature,
+            shared_flag_feature,
             objcopy_embed_flags_feature,
             opt_feature,
             dbg_feature,
@@ -752,6 +766,8 @@ def _impl(ctx):
         features = [
             default_compile_flags_feature,
             default_link_flags_feature,
+            supports_dynamic_linker_feature,
+            shared_flag_feature,
             supports_pic_feature,
             objcopy_embed_flags_feature,
             opt_feature,
@@ -764,7 +780,9 @@ def _impl(ctx):
         features = [
             default_compile_flags_feature,
             default_link_flags_feature,
+            supports_dynamic_linker_feature,
             supports_pic_feature,
+            shared_flag_feature,
             objcopy_embed_flags_feature,
             opt_feature,
             dbg_feature,

--- a/example/BUILD
+++ b/example/BUILD
@@ -5,6 +5,12 @@ cc_library(
 )
 
 cc_binary(
+    name = "example_lib.so",
+    linkshared = True,
+    deps = [":example_lib"],
+)
+
+cc_binary(
     name = "example",
     srcs = ["main.cpp"],
     deps = [":example_lib"],


### PR DESCRIPTION
Adds `-shared` flag to all dynamic link actions.

Before this was added, any attempt to create a `.so` file in the common manner (see below) would lead to an "undefined reference to main" at link time. This is due to the linker not being passed a `-shared` flag when attempting to dynamically link.

```
cc_binary(
  name = "mylib.so",
  srcs = ["mylib.cpp"],
)
```